### PR TITLE
Filtering Rule Config and TeamVsFieldRowRankedMktView fixes

### DIFF
--- a/lib/output_models/event_cfg.dart
+++ b/lib/output_models/event_cfg.dart
@@ -294,7 +294,7 @@ extension EventCfgTreeExt1 on EventCfgTree {
 
   TvFilterCfg? tvFilteringRules(AppScreen screen) {
     //
-    return screenAreaCfg(screen, ScreenWidgetArea.tableview).filterRules;
+    return screenAreaCfg(screen, ScreenWidgetArea.filterBar).filterRules;
   }
 
   TvAreaRowStyle tableRowStyleFor(AppScreen screen) {

--- a/lib/questions/user_rule_response_types.dart
+++ b/lib/questions/user_rule_response_types.dart
@@ -194,7 +194,8 @@ class TvSortGroupFilterBase extends RuleResponseBase {
     // );
   }
 
-  SortGroupFilterEntry get item1 => fieldList.first;
+  SortGroupFilterEntry get item1 =>
+      fieldList.length > 0 ? fieldList.first : SortGroupFilterEntry.noop();
   SortGroupFilterEntry? get item2 => fieldList.length > 1 ? fieldList[1] : null;
   SortGroupFilterEntry? get item3 => fieldList.length > 2 ? fieldList[2] : null;
 

--- a/st_ui_builder/lib/main.dart
+++ b/st_ui_builder/lib/main.dart
@@ -174,10 +174,24 @@ class _MarketViewScreenState extends ConsumerState<MarketViewScreen> {
       ),
       body: ListView(
         children: [
-          if (hasColumnFilters)
+          if (hasColumnFilters) ...{
             tvMgr.columnFilterBarWidget(
               backColor: StColors.primaryDarkGray,
             ),
+            SizedBox(
+              height: 520.h,
+              child: GroupedListView<TableviewDataRowTuple, GroupHeaderData>(
+                elements: tvMgr.listData,
+                groupBy: tvMgr.groupBy,
+                groupHeaderBuilder: tvMgr.groupHeaderBuilder,
+                indexedItemBuilder: tvMgr.indexedItemBuilder,
+                sort: true,
+                useStickyGroupSeparators: true,
+                // next line should not be needed??
+                groupComparator: tvMgr.groupComparator,
+              ),
+            ),
+          },
           Container(
             height: 30,
           ),
@@ -217,7 +231,6 @@ class _MarketViewScreenState extends ConsumerState<MarketViewScreen> {
             label: "TeamVsField Row Market Reasearch View",
             row: TeamVsFieldRowMktResearchView(assetRows.first),
           ),
-
           DemoRow(
             label: "AssetVsAsset Row Portfolio View",
             row: AssetVsAssetRowPortfolioView(assetRows.first),
@@ -254,20 +267,6 @@ class _MarketViewScreenState extends ConsumerState<MarketViewScreen> {
             label: "TeamplayerVsField Row Leaderboard View",
             row: TeamPlayerVsFieldLeaderBoardView(assetRows.first),
           ),
-          // Container(
-          //   height: hasColumnFilters ? 500.h : 740.h,
-          //   padding: EdgeInsets.fromLTRB(20.w, 0, 20.w, 10.h),
-          //   child: GroupedListView<TableviewDataRowTuple, GroupHeaderData>(
-          //     elements: tvMgr.listData,
-          //     groupBy: tvMgr.groupBy,
-          //     groupHeaderBuilder: tvMgr.groupHeaderBuilder,
-          //     indexedItemBuilder: tvMgr.indexedItemBuilder,
-          //     sort: true,
-          //     useStickyGroupSeparators: true,
-          // next line should not be needed??
-          // groupComparator: tvMgr.groupComparator,
-          //   ),
-          // ),
         ],
       ),
       // floatingActionButton: FloatingActionButton(onPressed: _updateGameStatus),

--- a/st_ui_builder/lib/ui_builder/row_style_widgets.dart
+++ b/st_ui_builder/lib/ui_builder/row_style_widgets.dart
@@ -668,7 +668,7 @@ class TeamVsFieldRowMktView extends StBaseTvRow
 class TeamVsFieldRowRankedMktView extends TeamVsFieldRowMktView {
   //
   @override
-  bool get showRanked => true;
+  bool get isPlayerVsFieldRanked => true;
 
   const TeamVsFieldRowRankedMktView(
     TableviewDataRowTuple assets, {


### PR DESCRIPTION
- Overrides isPlayerVsFieldRanked instead of showRanked for TeamVsFieldRowRankedMktView
- Specifies ScreenWidgetArea.filterBar as ScreenWidgetArea for tvFilteringRules method
- Uses SortGroupFilterEntry.noop() for TvSortGroupFilterBase.item1 when fieldList is empty