### PR TITLE
FIX: Disabling Event Grouping

### DIFF
--- a/lib/questions/user_rule_response_types.dart
+++ b/lib/questions/user_rule_response_types.dart
@@ -132,10 +132,6 @@ class SortGroupFilterEntry {
 
   SortGroupFilterEntry(this.colName, this.asc);
 
-  factory SortGroupFilterEntry.noop() {
-    return SortGroupFilterEntry(DbTableFieldName.imageUrl, false);
-  }
-
   bool get sortingDisabled => colName == DbTableFieldName.imageUrl;
 
   @override
@@ -194,12 +190,12 @@ class TvSortGroupFilterBase extends RuleResponseBase {
     // );
   }
 
-  SortGroupFilterEntry get item1 =>
-      fieldList.length > 0 ? fieldList.first : SortGroupFilterEntry.noop();
+  SortGroupFilterEntry? get item1 =>
+      fieldList.length > 0 ? fieldList.first : null;
   SortGroupFilterEntry? get item2 => fieldList.length > 1 ? fieldList[1] : null;
   SortGroupFilterEntry? get item3 => fieldList.length > 2 ? fieldList[2] : null;
 
-  DbTableFieldName get firstColName => item1.colName;
+  DbTableFieldName? get firstColName => item1?.colName;
 
   @override
   String toString() {
@@ -231,7 +227,8 @@ class TvSortCfg extends TvSortGroupFilterBase {
 
   bool get disableSorting => fieldList.length < 1;
 
-  SortGroupFilterEntry get first => fieldList.first;
+  SortGroupFilterEntry? get first =>
+      fieldList.length < 1 ? null : fieldList.first;
   SortGroupFilterEntry? get second =>
       fieldList.length < 2 ? null : fieldList[1];
   SortGroupFilterEntry? get third => fieldList.length < 3 ? null : fieldList[2];

--- a/st_ui_builder/lib/ui_builder/factory.dart
+++ b/st_ui_builder/lib/ui_builder/factory.dart
@@ -88,9 +88,7 @@ class StUiBuilderFactory {
     /* build object that wraps all data and display rules
     */
 
-    // hack for Nascar b4 configurator is updated
-    bool disableAllGrouping = _eConfig!.eventCfg.skipGroupingOnScreen(screen) ||
-        _eConfig!.eventCfg.skipGroupingForName('nascar');
+    bool disableAllGrouping = _eConfig!.eventCfg.skipGroupingOnScreen(screen);
 
     CfgForAreaAndNestedSlots tableAreaAndSlotCfg =
         _eConfig!.screenAreaCfg(screen, ScreenWidgetArea.tableview);

--- a/st_ui_builder/lib/ui_builder/group_header_build_payload.dart
+++ b/st_ui_builder/lib/ui_builder/group_header_build_payload.dart
@@ -31,7 +31,8 @@ class GroupHeaderData
     // NOT the sort values (comparables) used in sortComparator below
 
     firstLabelFn(AssetRowPropertyIfc row) {
-      return row.labelExtractor(sortAndGroupRules.item1.colName);
+      if (sortAndGroupRules.item1 == null) return '';
+      return row.labelExtractor(sortAndGroupRules.item1!.colName);
     }
 
     SortGroupFilterEntry? col2Rule = sortAndGroupRules.item2;
@@ -50,7 +51,8 @@ class GroupHeaderData
 
     // sorting functions
     firstValFn(AssetRowPropertyIfc row) {
-      return row.sortValueExtractor(sortAndGroupRules.item1.colName);
+      if (sortAndGroupRules.item1 == null) return '';
+      return row.sortValueExtractor(sortAndGroupRules.item1!.colName);
     }
 
     // CastRowToSortVal
@@ -126,7 +128,8 @@ class GroupHeaderData
     // WITHIN groups;  this does NOT sort-order the groups
     // GroupHeaderData (comparable._sortKey) controls groups
     firstValFn(AssetRowPropertyIfc row) {
-      return row.sortValueExtractor(sr.item1.colName);
+      if (sr.item1 == null) return '';
+      return row.sortValueExtractor(sr.item1!.colName);
     }
 
     SortGroupFilterEntry? col2Rule = sr.item2;

--- a/st_ui_builder/lib/ui_builder/tv_grouped_data_mgr.dart
+++ b/st_ui_builder/lib/ui_builder/tv_grouped_data_mgr.dart
@@ -98,9 +98,7 @@ class GroupedTableDataMgr {
       sortingRules, sortOrder == GroupedListOrder.ASC);
 
   bool get hasColumnFilters {
-    // set imageUrl as first filter field to hide/disable the whole filter bar
-    return filterRules?.item1.colName != DbTableFieldName.imageUrl &&
-        !disableAllGrouping;
+    return filterRules?.item1 != null && !disableAllGrouping;
   }
 
   void endGeographicGrouping() {
@@ -123,18 +121,18 @@ class GroupedTableDataMgr {
       return const SizedBox.shrink();
     }
 
-    SortGroupFilterEntry i1 = filterRules!.item1;
+    SortGroupFilterEntry? i1 = filterRules!.item1;
     SortGroupFilterEntry? i2 = filterRules!.item2;
     SortGroupFilterEntry? i3 = filterRules!.item3;
 
-    Set<String> listItems1 = _getListItemsByCfgField(i1);
+    Set<String> listItems1 = i1 == null ? {} : _getListItemsByCfgField(i1);
     Set<String> listItems2 = i2 == null ? {} : _getListItemsByCfgField(i2);
     Set<String> listItems3 = i3 == null ? {} : _getListItemsByCfgField(i3);
 
     const _kLstMin = 2;
 
     bool has2ndList =
-        i2 != null && listItems2.length > _kLstMin && i2.colName != i1.colName;
+        i2 != null && listItems2.length > _kLstMin && i2.colName != i1?.colName;
     bool has3rdList =
         i3 != null && listItems3.length > _kLstMin && i3.colName != i2!.colName;
 
@@ -143,6 +141,8 @@ class GroupedTableDataMgr {
     double allocBtnWidth = totAvailWidth / dropLstCount;
     // one list can take 86% of space
     allocBtnWidth = dropLstCount < 2 ? totAvailWidth * 0.86 : allocBtnWidth;
+
+    if (i1 == null) return const SizedBox.shrink();
 
     return Container(
       height: barHeight,

--- a/st_ui_builder/lib/ui_builder/tv_header_widgets.dart
+++ b/st_ui_builder/lib/ui_builder/tv_header_widgets.dart
@@ -19,10 +19,19 @@ class TvGroupHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // standard group header widget
-    // print('building a TvGroupHeader first: ${headerData.first}');
+    if (headerData.h1Displ.isEmpty && headerData.h2Displ.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    double height = 0;
+    if (headerData.h1Displ.isNotEmpty) {
+      height += 39;
+    }
+    if (headerData.h2Displ.isNotEmpty) {
+      height += 39;
+    }
     return Container(
-      height: 58,
-      padding: const EdgeInsets.only(top: 4),
+      height: height.h,
+      padding: EdgeInsets.only(top: 4.h, bottom: 8.h),
       color: StColors.black,
       child: _rowStyleToHeaderStyle(),
     );
@@ -38,13 +47,14 @@ class TvGroupHeader extends StatelessWidget {
           headerData.h1Displ,
           style: StTextStyles.h4,
         ),
-        // Spacer(),
-        Text(
-          headerData.h2Displ,
-          style: StTextStyles.h6.copyWith(
-            color: Colors.grey,
+
+        if (headerData.h2Displ.isNotEmpty)
+          Text(
+            headerData.h2Displ,
+            style: StTextStyles.h6.copyWith(
+              color: Colors.grey,
+            ),
           ),
-        ),
         // Spacer(),
         // Text(headerData.third),
       ],

--- a/st_ui_builder/pubspec.yaml
+++ b/st_ui_builder/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.1+2
+version: 1.0.1+4
 
 environment:
   sdk: ">=2.17.6 <3.0.0"

--- a/st_ui_builder/test/load_test.dart
+++ b/st_ui_builder/test/load_test.dart
@@ -1,4 +1,3 @@
-import 'package:grouped_list/sliver_grouped_list.dart';
 import 'package:st_ev_cfg/st_ev_cfg.dart';
 import 'package:test/test.dart';
 
@@ -40,12 +39,12 @@ void main() {
         reason: 'json HAS filtering rules',
       );
       expect(
-        trdm.filterRules?.item1.colName,
+        trdm.filterRules?.item1?.colName,
         DbTableFieldName.assetName,
         reason: 'json specifies 1 filter menu on assetName',
       );
       expect(
-        trdm.groupingRules?.item1.colName,
+        trdm.groupingRules?.item1?.colName,
         DbTableFieldName.assetOrgName,
         reason: 'json specifies grouping on 2 fields; first is assetOrgName',
       );


### PR DESCRIPTION
- Removes `SortGroupFilterEntry.noop` constructor
- Makes first `SortGroupFilterEntry` nullable and updates implementation that depended on a non-null type
- Updates `TvGroupHeader` widget
- Removes hack for disabling grouping for NASCAR event