### PR TITLE
Fix/assetOrgName filter title and grouping fixes

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: builds scoretrader event config payload
 
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.1.1+3
+version: 1.1.1+5
 
 environment:
   sdk: ">=2.17.6 <3.0.0"

--- a/st_ui_builder/lib/ui_builder/row_data_top_ifc.dart
+++ b/st_ui_builder/lib/ui_builder/row_data_top_ifc.dart
@@ -141,7 +141,7 @@ extension AssetRowPropertyIfcExt1 on AssetRowPropertyIfc {
       case DbTableFieldName.assetShortName:
         return subName;
       case DbTableFieldName.assetOrgName:
-        return subName;
+        return teamNameWhenTradingPlayers;
       case DbTableFieldName.conference:
         return regionOrConference;
       case DbTableFieldName.region:
@@ -179,7 +179,7 @@ extension AssetRowPropertyIfcExt1 on AssetRowPropertyIfc {
       case DbTableFieldName.assetShortName:
         return subName;
       case DbTableFieldName.assetOrgName:
-        return subName;
+        return teamNameWhenTradingPlayers;
       case DbTableFieldName.conference:
         return regionOrConference;
       case DbTableFieldName.region:

--- a/st_ui_builder/lib/ui_builder/tv_grouped_data_mgr.dart
+++ b/st_ui_builder/lib/ui_builder/tv_grouped_data_mgr.dart
@@ -607,11 +607,10 @@ class _AssetRowsListView extends StatelessWidget {
     return Column(
       children: [
         for (int i = 0; i < assets.length; i++) ...{
-          //logic to display one header for grouped assets
+          //logic to display date header for grouped assets
           if (i == 0 ||
-              (i + 1 < assets.length &&
-                  groupBy(assets[i])._sortKey !=
-                      groupBy(assets[i + 1])._sortKey)) ...{
+              groupBy(assets[i])._sortKey !=
+                  groupBy(assets[i - 1])._sortKey) ...{
             groupHeaderBuilder(assets[i]),
           },
           rowBuilder(

--- a/st_ui_builder/lib/ui_builder/tv_grouped_data_mgr.dart
+++ b/st_ui_builder/lib/ui_builder/tv_grouped_data_mgr.dart
@@ -289,6 +289,7 @@ class GroupedTableDataMgr {
       _filterTitleExtractor(filterItem.colName),
       ...sortedAssetRows.map((e) => e.labelExtractor(filterItem.colName)),
     ];
+    labels.removeWhere((label) => label.isEmpty);
 
     return <String>{...labels};
   }


### PR DESCRIPTION
- Fixes date header logic for grouped assets
- Returns `teamNameWhenTradingPlayers` for `assetOrgName` in label and sort extractors
- Removes empty string filter options